### PR TITLE
Fix channel registration in order to fix exploit

### DIFF
--- a/velocity/src/main/java/io/github/_4drian3d/signedvelocity/velocity/SignedVelocity.java
+++ b/velocity/src/main/java/io/github/_4drian3d/signedvelocity/velocity/SignedVelocity.java
@@ -7,6 +7,7 @@ import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.PluginManager;
+import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import io.github._4drian3d.signedvelocity.velocity.listener.Listener;
@@ -37,6 +38,8 @@ public final class SignedVelocity {
   private Metrics.Factory factory;
   @Inject
   private PluginManager pluginManager;
+  @Inject
+  private ProxyServer server;
 
   @Subscribe
   public void onProxyInitialization(final ProxyInitializeEvent event) {
@@ -46,5 +49,6 @@ public final class SignedVelocity {
 
     Listener.register(injector);
     PacketAdapter.register(injector, pluginManager);
+    server.getChannelRegistrar().register(SIGNEDVELOCITY_CHANNEL);
   }
 }


### PR DESCRIPTION
You never actually registered the SignedVelocity Channel (signedvelocity:main) on the proxy, so the exploit was never patched.