### PR TITLE
prevent players with ChatResult.DENIED from sending messages

### DIFF
--- a/velocity/src/main/java/io/github/_4drian3d/signedvelocity/velocity/listener/PlayerChatListener.java
+++ b/velocity/src/main/java/io/github/_4drian3d/signedvelocity/velocity/listener/PlayerChatListener.java
@@ -26,8 +26,12 @@ final class PlayerChatListener implements Listener<PlayerChatEvent> {
 
             // Denied
             // | The player has an old version, so you can safely deny execution from Velocity
-            if (!result.isAllowed() && player.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_19_1) < 0) {
+            if (player.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_19_1) < 0) {
                 continuation.resume();
+                return;
+            }
+
+            if (!result.isAllowed()) {
                 return;
             }
 


### PR DESCRIPTION
I noticed an incorrect if statement that wasn't cancelling messages from for example muted players (cancelled by velocity plugin). My small change fixes this.