### PR TITLE
Add Paper and Fabric 26.1.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Allows you to cancel or modify messages or commands from Velocity without synchr
 - Paper 1.20+ 
 - Sponge 10/12+
 - [Minestom](https://github.com/4drian3d/SignedVelocity?tab=readme-ov-file#minestom)
-- Fabric 1.21+
+- Fabric 26.1.2+
 
 ## Features
 - Transmit the modification and cancellation status of Velocity messages and commands to your backend server using plugin messages. This avoids chat chain synchronization problems and avoids Velocity's security check by correctly synchronizing messages.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Allows you to cancel or modify messages or commands from Velocity without synchr
 - Java 21+
 - Velocity 3.4.0+
 #### **Backend:**
-- Paper 1.20+ 
+- Paper 26.1.2+
 - Sponge 10/12+
 - [Minestom](https://github.com/4drian3d/SignedVelocity?tab=readme-ov-file#minestom)
 - Fabric 26.1.2+

--- a/backend/fabric/build.gradle.kts
+++ b/backend/fabric/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("fabric-loom")
+    id("net.fabricmc.fabric-loom")
     alias(libs.plugins.shadow)
 }
 
@@ -7,9 +7,8 @@ val shade: Configuration by configurations.creating
 
 dependencies {
     minecraft(libs.minecraft)
-    mappings(loom.officialMojangMappings())
-    modImplementation(libs.fabric.loader)
-    modImplementation(libs.fabric.api)
+    implementation(libs.fabric.loader)
+    implementation(libs.fabric.api)
 
     shadeModule(projects.signedvelocityBackendCommon)
     shadeModule(projects.signedvelocityShared)
@@ -33,8 +32,8 @@ tasks {
             expand("version" to project.version)
         }
     }
-    remapJar {
-        inputFile.set(shadowJar.get().archiveFile)
+    jar {
+//        inputFile.set(shadowJar.get().archiveFile)
         archiveFileName.set("${rootProject.name}-Fabric-${project.version}.jar")
         destinationDirectory.set(file("${rootProject.projectDir}/build"))
     }

--- a/backend/fabric/build.gradle.kts
+++ b/backend/fabric/build.gradle.kts
@@ -26,16 +26,13 @@ fun DependencyHandlerScope.shadeModule(module: ProjectDependency) {
 tasks {
     shadowJar {
         configurations = listOf(shade)
+        archiveFileName.set("${rootProject.name}-Fabric-${project.version}.jar")
+        destinationDirectory.set(file("${rootProject.projectDir}/build"))
     }
     processResources {
         filesMatching("fabric.mod.json") {
             expand("version" to project.version)
         }
-    }
-    jar {
-//        inputFile.set(shadowJar.get().archiveFile)
-        archiveFileName.set("${rootProject.name}-Fabric-${project.version}.jar")
-        destinationDirectory.set(file("${rootProject.projectDir}/build"))
     }
 }
 

--- a/backend/fabric/src/main/java/io/github/_4drian3d/signedvelocity/fabric/SignedVelocity.java
+++ b/backend/fabric/src/main/java/io/github/_4drian3d/signedvelocity/fabric/SignedVelocity.java
@@ -10,13 +10,13 @@ import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class SignedVelocity implements DedicatedServerModInitializer {
   public static final Logger LOGGER = LoggerFactory.getLogger("SignedVelocity");
-  public static final ResourceLocation CHANNEL = ResourceLocation.fromNamespaceAndPath(
+  public static final Identifier CHANNEL = Identifier.fromNamespaceAndPath(
       SignedConstants.SIGNED_NAMESPACE, SignedConstants.SIGNED_CHANNEL);
   public static final SignedQueue CHAT_QUEUE = new SignedQueue();
   public static final SignedQueue COMMAND_QUEUE = new SignedQueue();
@@ -28,7 +28,7 @@ public final class SignedVelocity implements DedicatedServerModInitializer {
       CHAT_QUEUE.removeData(uuid);
       COMMAND_QUEUE.removeData(uuid);
     });
-    PayloadTypeRegistry.playC2S().register(QueuedDataPacket.PACKET_ID, QueuedDataPacket.PACKET_CODEC);
+    PayloadTypeRegistry.serverboundPlay().register(QueuedDataPacket.PACKET_ID, QueuedDataPacket.PACKET_CODEC);
     ServerPlayNetworking.registerGlobalReceiver(QueuedDataPacket.PACKET_ID, (packet, context) -> {
       final SignedQueue queue = switch (QueueType.getOrThrow(packet.source())) {
         case QueueType.COMMAND -> SignedVelocity.COMMAND_QUEUE;

--- a/backend/fabric/src/main/resources/fabric.mod.json
+++ b/backend/fabric/src/main/resources/fabric.mod.json
@@ -21,9 +21,9 @@
   },
   "depends": {
     "fabricloader": ">=0.15.11",
-    "fabric": ">=0.100.0",
+    "fabric-api": ">=0.100.0",
     "java": ">=21",
-    "minecraft": ">=1.21"
+    "minecraft": ">=26.1"
   },
   "mixins": [
     "signedvelocity.mixins.json"

--- a/backend/paper/build.gradle.kts
+++ b/backend/paper/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    paperweight.paperDevBundle("1.21.8-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("26.1.2.build.65-stable")
     implementation(projects.signedvelocityBackendCommon)
     implementation(projects.signedvelocityShared)
 }
@@ -30,7 +30,7 @@ tasks {
         }
     }
     runServer {
-        minecraftVersion("1.21.8")
+        minecraftVersion("26.1.2")
         jvmArgs("-Dcom.mojang.eula.agree=true")
     }
 }
@@ -41,6 +41,6 @@ paper {
     authors = listOf("4drian3d")
 
     foliaSupported = true
-    apiVersion = "1.21"
+    apiVersion = "26.1"
     website = "https://modrinth.com/plugin/signedvelocity"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,12 +7,12 @@ allprojects {
     tasks {
         withType<JavaCompile> {
             options.encoding = Charsets.UTF_8.name()
-            options.release.set(21)
+            options.release.set(25)
         }
     }
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(21))
+            languageVersion.set(JavaLanguageVersion.of(25))
             vendor.set(JvmVendorSpec.AZUL)
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ shadow = "9.6.1"
 runvelocity = "3.0.2"
 
 bstats = "3.2.1"
+fastutil = "8.5.15"
 
 fabric-api = "0.148.0+26.1.2"
 fabric-loader = "0.19.3"
@@ -31,6 +32,7 @@ fabric-api = { group = "net.fabricmc.fabric-api", name = "fabric-api", version.r
 fabric-loader = { group = "net.fabricmc", name = "fabric-loader", version.ref = "fabric-loader" }
 
 bstats = { module = "org.bstats:bstats-velocity", version.ref = "bstats" }
+fastutil = { group = "it.unimi.dsi", name = "fastutil", version.ref = "fastutil" }
 
 packetevents-velocity = { group = "com.github.retrooper", name = "packetevents-velocity", version = "2.13.0" }
 packetevents-paper = { group = "com.github.retrooper", name = "packetevents-spigot", version = "2.12.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,10 +3,10 @@ metadata.format.version = "1.1"
 [versions]
 
 # CompileOnly dependencies
-velocity = "3.4.0-SNAPSHOT"
+velocity = "3.5.0-SNAPSHOT"
 paper = "26.1.2.build.65-stable"
 minestom-server = "2025.10.05-1.21.8"
-minecraft = "1.21.9-rc1"
+minecraft = "26.1.2"
 
 # Gradle Plugins
 blossom = "2.2.0"
@@ -15,7 +15,7 @@ runvelocity = "3.0.2"
 
 bstats = "3.2.1"
 
-fabric-api = "0.133.14+1.21.9"
+fabric-api = "0.148.0+26.1.2"
 fabric-loader = "0.19.3"
 
 [libraries]

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 dependencies {
     compileOnly(libs.velocity.api)
     compileOnly(libs.velocity.proxy)
+    compileOnly(libs.fastutil)
     annotationProcessor(libs.velocity.api)
     implementation(libs.bstats)
 


### PR DESCRIPTION
**Updated Fabric backend to Minecraft 26.1.2**

Updates the Paper and Fabric backends for Minecraft 26.1.2 and their matching APIs. It also updates the Fabric payload registration and keeps the shaded Fabric JAR at the CI artifact path.